### PR TITLE
Correcting variable name for node status

### DIFF
--- a/src/nodectl/status.py
+++ b/src/nodectl/status.py
@@ -75,7 +75,7 @@ class Status(object):
                 output.update(service_status)
 
             overall_status = str(status)
-            if "ok" not in status.lower():
+            if "ok" not in overall_status.lower():
                 output.update({"status": "bad"})
 
             self.output = json.dumps(output)


### PR DESCRIPTION
Correcting variable name so that node status works correctly on fresh install of  ovirt-node-4.1