### PR TITLE
profile.d scripts: Skip for non-interactive shells

### DIFF
--- a/scripts/nodectl-motd.sh
+++ b/scripts/nodectl-motd.sh
@@ -1,1 +1,2 @@
-nodectl motd
+# Skip for noninteractive shells
+[ "$PS1" ] && nodectl motd

--- a/scripts/nodectl-run-banner.sh
+++ b/scripts/nodectl-run-banner.sh
@@ -1,1 +1,2 @@
-nodectl generate-banner
+# Skip for noninteractive shells
+[ "$PS1" ] && nodectl generate-banner


### PR DESCRIPTION
Since "forever", on RHEL-/Fedora-based OSes, /etc/profile.d/*.sh scripts
are sourced by both interactive and non-interactive shells, despite what
one might guess from the name, where for non-interactive shells the
output goes to /dev/null:

https://pagure.io/setup/c/722b1261

Skip calling nodectl for non-interactive shells, as it's just a waste of
time.

Change-Id: I0b862464061fb155aa7f4b43957ee4d94920f653
Signed-off-by: Yedidyah Bar David <didi@redhat.com>

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]