### PR TITLE
build: Added workaround for the issue caused by a CVE-2022-24765 fix

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,4 +1,13 @@
-srpm:
+git_cfg_safe:
+	# Workaround for CVE-2022-24765 fix:
+	#
+	#	fatal: unsafe repository ('/path' is owned by someone else)
+	#
+	# Since copr build process first clones the repo, and then uses mock to run the build
+	#
+	git config --global --add safe.directory "$(shell pwd)"
+
+srpm: git_cfg_safe
 	dnf -y install git autoconf automake make python3-devel
 	./autogen.sh --disable-image --disable-docs --disable-tool
 	make srpm


### PR DESCRIPTION
Latest git seems to fail if the directory is not owned by the current
user.

Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Workaround for the issue caused by the git CVE fix.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]